### PR TITLE
Fix/android check background profile before building

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,40 @@ A collection of examples showcasing the usage of the SDK is available [here](doc
 
 You can also refer to the [ExampleApp](android/ExampleApp) which demonstrates the integration and usage of the SDK.
 
+### Development and Contribution
+#### Code style
+The code style of the android project (java/kotlin) is checked by spotless plugin according to the [eclipse config](android/eclipse-java-google-style.xml).<br/>
+If you want to adjust the config, please refer to the [guide](https://github.com/diffplug/spotless/blob/0842bfa67ff0a6b289fc8a924a314d194e0d50d5/ECLIPSE_SCREENSHOTS.md) at spotless GitHub repo.
+
+Check the code style:
+```
+cd android/
+./gradlew spotlessCheck
+```
+
+Auto-Fix all found issues with the code style:
+```
+cd android/
+./gradlew spotlessApply
+```
+
+#### Tests
+The android project uses `junit4` with `androidx`/`robolectric` test utils.<br/>
+Run all unit tests from the scratch:
+```
+cd android/
+./gradlew clean testRelease
+```
+
+#### Android Linter
+In spite of the project is written in Java, it is developed taking into account the possibility of invocation from Kotlin too.<br/>
+Java/Kotlin interoperability can be checked by the android linter:
+```
+cd android/
+./gradlew lint
+```
+
+Check the root `build.gradle` to see all code restrictions for interoperability between Java and Kotlin.
 
 ## iOS
 Fjuul SDK for iOS is written in Swift, and published as an SPM package.

--- a/android/activitysources/src/main/java/com/fjuul/sdk/activitysources/entities/ActivitySourcesManagerConfig.java
+++ b/android/activitysources/src/main/java/com/fjuul/sdk/activitysources/entities/ActivitySourcesManagerConfig.java
@@ -305,6 +305,8 @@ public class ActivitySourcesManagerConfig {
                 "GoogleFit intraday background sync mode must be set");
             Objects.requireNonNull(config.googleFitSessionsBackgroundSyncMode,
                 "GoogleFit sessions background sync mode must be set");
+            Objects.requireNonNull(config.profileBackgroundSyncMode,
+                "GoogleFit profile background sync mode must be set");
             Objects.requireNonNull(config.collectableFitnessMetrics, "Collectable fitness metrics must be set");
             this.created = true;
             return config;

--- a/android/activitysources/src/test/java/com/fjuul/sdk/activitysources/entities/ActivitySourcesManagerConfigTest.java
+++ b/android/activitysources/src/test/java/com/fjuul/sdk/activitysources/entities/ActivitySourcesManagerConfigTest.java
@@ -1,0 +1,45 @@
+package com.fjuul.sdk.activitysources.entities;
+
+import android.os.Build;
+
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.time.Duration;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.*;
+
+@RunWith(Enclosed.class)
+public class ActivitySourcesManagerConfigTest {
+
+    @RunWith(RobolectricTestRunner.class)
+    @Config(sdk = {Build.VERSION_CODES.P})
+    public abstract static class GivenRobolectricContext {}
+
+    public static class BuilderTests extends GivenRobolectricContext {
+        @Test
+        public void build_whenProfileBackgroundSyncModeIsNotSet_throwsException() {
+            final ActivitySourcesManagerConfig.Builder subject = new ActivitySourcesManagerConfig.Builder();
+            subject.setCollectableFitnessMetrics(
+                Stream.of(FitnessMetricsType.INTRADAY_STEPS,
+                    FitnessMetricsType.INTRADAY_CALORIES,
+                    FitnessMetricsType.INTRADAY_HEART_RATE).collect(Collectors.toSet()))
+                .enableGoogleFitBackgroundSync(Duration.ofMinutes(60));
+            try {
+                subject.build();
+                assertTrue("should throw the exception", false);
+            } catch (Exception exc) {
+                assertThat(exc, instanceOf(NullPointerException.class));
+                assertEquals("should have message",
+                    "GoogleFit profile background sync mode must be set",
+                    exc.getMessage());
+            }
+        }
+    }
+}

--- a/android/activitysources/src/test/java/com/fjuul/sdk/activitysources/entities/ActivitySourcesManagerConfigTest.java
+++ b/android/activitysources/src/test/java/com/fjuul/sdk/activitysources/entities/ActivitySourcesManagerConfigTest.java
@@ -1,6 +1,11 @@
 package com.fjuul.sdk.activitysources.entities;
 
-import android.os.Build;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.*;
+
+import java.time.Duration;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
@@ -8,12 +13,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
-import java.time.Duration;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.*;
+import android.os.Build;
 
 @RunWith(Enclosed.class)
 public class ActivitySourcesManagerConfigTest {
@@ -26,10 +26,13 @@ public class ActivitySourcesManagerConfigTest {
         @Test
         public void build_whenProfileBackgroundSyncModeIsNotSet_throwsException() {
             final ActivitySourcesManagerConfig.Builder subject = new ActivitySourcesManagerConfig.Builder();
-            subject.setCollectableFitnessMetrics(
-                Stream.of(FitnessMetricsType.INTRADAY_STEPS,
-                    FitnessMetricsType.INTRADAY_CALORIES,
-                    FitnessMetricsType.INTRADAY_HEART_RATE).collect(Collectors.toSet()))
+            subject
+                .setCollectableFitnessMetrics(
+                    Stream
+                        .of(FitnessMetricsType.INTRADAY_STEPS,
+                            FitnessMetricsType.INTRADAY_CALORIES,
+                            FitnessMetricsType.INTRADAY_HEART_RATE)
+                        .collect(Collectors.toSet()))
                 .enableGoogleFitBackgroundSync(Duration.ofMinutes(60));
             try {
                 subject.build();


### PR DESCRIPTION
*  Fix: check if the profile background sync mode is set when building ActivitySourcesManagerConfig
*  Add unit-test
*  Update README.md: add 'Development and Contribution' section for android

fixes #67