### PR TITLE
add getAggregatedDailyStats

### DIFF
--- a/android/ExampleApp/app/src/main/java/com/fjuul/sdk/android/exampleapp/ui/aggregated_daily_stats/AggregatedDailyStatsFragment.kt
+++ b/android/ExampleApp/app/src/main/java/com/fjuul/sdk/android/exampleapp/ui/aggregated_daily_stats/AggregatedDailyStatsFragment.kt
@@ -1,0 +1,116 @@
+package com.fjuul.sdk.android.exampleapp.ui.aggregated_daily_stats
+
+import android.app.DatePickerDialog
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.LinearLayout
+import android.widget.RadioButton
+import android.widget.RadioGroup
+import android.widget.TextView
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Observer
+import com.fjuul.sdk.android.exampleapp.R
+import java.time.LocalDate
+
+class AggregatedDailyStatsFragment : Fragment() {
+    private lateinit var fromInput: View
+    private lateinit var toInput: View
+    private lateinit var fromValueText: TextView
+    private lateinit var toValueText: TextView
+    private lateinit var radioGroup: RadioGroup
+    private lateinit var aggregatedStats: TextView
+
+    private val model: AggregatedDailyStatsViewModel by viewModels()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.fragment_aggregated_daily_stats, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        fromInput = view.findViewById<LinearLayout>(R.id.from_input_layout)
+        toInput = view.findViewById<LinearLayout>(R.id.to_input_layout)
+        fromValueText = view.findViewById(R.id.from_value_text)
+        toValueText = view.findViewById(R.id.to_value_text)
+        radioGroup = view.findViewById<RadioGroup>(R.id.aggregate_radio_group)
+        aggregatedStats = view.findViewById(R.id.aggregated_stats)
+
+        when (model.aggregation.value) {
+            AggregationType.sum -> view.findViewById<RadioButton>(R.id.radio_sum).isChecked = true
+            AggregationType.avg -> view.findViewById<RadioButton>(R.id.radio_avg).isChecked = true
+        }
+
+        model.requestData()
+        model.startDate.observe(
+            viewLifecycleOwner,
+            Observer { date ->
+                fromValueText.text = date.toString()
+            }
+        )
+        model.endDate.observe(
+            viewLifecycleOwner,
+            Observer {
+                toValueText.text = it.toString()
+            }
+        )
+
+        val adapter = AggregatedDailyStatsAdapter(requireContext())
+        aggregatedStats.adapter = adapter
+        model.data.observe(
+            viewLifecycleOwner,
+            Observer {
+                adapter.dataSource = it
+                adapter.notifyDataSetChanged()
+            }
+        )
+
+        fromInput.setOnClickListener {
+            val date = model.startDate.value!!
+            DatePickerDialog(
+                requireContext(),
+                DatePickerDialog.OnDateSetListener { _, year, month, dayOfMonth ->
+                    model.setupDateRange(startDate = LocalDate.of(year, month + 1, dayOfMonth))
+                },
+                date.year,
+                date.monthValue - 1,
+                date.dayOfMonth
+            ).show()
+        }
+
+        toInput.setOnClickListener {
+            val date = model.endDate.value!!
+            DatePickerDialog(
+                requireContext(),
+                DatePickerDialog.OnDateSetListener { _, year, month, dayOfMonth ->
+                    model.setupDateRange(endDate = LocalDate.of(year, month + 1, dayOfMonth))
+                },
+                date.year,
+                date.monthValue - 1,
+                date.dayOfMonth
+            ).show()
+        }
+
+        radioGroup.setOnCheckedChangeListener { group, checkedId ->
+            when (checkedId) {
+                R.id.radio_sum -> model.setAggregation(AggregationType.sum)
+                R.id.radio_avg -> model.setAggregation(AggregationType.avg)
+            }
+        }
+    }
+
+    companion object {
+        @JvmStatic
+        fun newInstance() =
+            AggregatedDailyStatsFragment().apply {
+                arguments = Bundle()
+            }
+    }
+}

--- a/android/ExampleApp/app/src/main/java/com/fjuul/sdk/android/exampleapp/ui/aggregated_daily_stats/AggregatedDailyStatsFragment.kt
+++ b/android/ExampleApp/app/src/main/java/com/fjuul/sdk/android/exampleapp/ui/aggregated_daily_stats/AggregatedDailyStatsFragment.kt
@@ -66,7 +66,8 @@ class AggregatedDailyStatsFragment : Fragment() {
         model.data.observe(
             viewLifecycleOwner,
             Observer { it ->
-                aggregatedStats.text = """
+                aggregatedStats.text =
+                    """
  low: ${it.low.metMinutes} metMinutes;
  moderate: ${it.moderate.metMinutes} metMinutes;
  high: ${it.high.metMinutes} metMinutes"""

--- a/android/ExampleApp/app/src/main/java/com/fjuul/sdk/android/exampleapp/ui/aggregated_daily_stats/AggregatedDailyStatsFragment.kt
+++ b/android/ExampleApp/app/src/main/java/com/fjuul/sdk/android/exampleapp/ui/aggregated_daily_stats/AggregatedDailyStatsFragment.kt
@@ -13,6 +13,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import com.fjuul.sdk.android.exampleapp.R
+import com.fjuul.sdk.analytics.entities.AggregationType
 import java.time.LocalDate
 
 class AggregatedDailyStatsFragment : Fragment() {
@@ -62,13 +63,20 @@ class AggregatedDailyStatsFragment : Fragment() {
             }
         )
 
-        val adapter = AggregatedDailyStatsAdapter(requireContext())
-        aggregatedStats.adapter = adapter
         model.data.observe(
             viewLifecycleOwner,
-            Observer {
-                adapter.dataSource = it
-                adapter.notifyDataSetChanged()
+            Observer { it ->
+                aggregatedStats.text = """
+ low: ${it.low.metMinutes} metMinutes;
+ moderate: ${it.moderate.metMinutes} metMinutes;
+ high: ${it.high.metMinutes} metMinutes"""
+            }
+        )
+
+        model.errorMessage.observe(
+            viewLifecycleOwner,
+            Observer { it ->
+                aggregatedStats.text = it.toString()
             }
         )
 

--- a/android/ExampleApp/app/src/main/java/com/fjuul/sdk/android/exampleapp/ui/aggregated_daily_stats/AggregatedDailyStatsFragment.kt
+++ b/android/ExampleApp/app/src/main/java/com/fjuul/sdk/android/exampleapp/ui/aggregated_daily_stats/AggregatedDailyStatsFragment.kt
@@ -12,8 +12,8 @@ import android.widget.TextView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
-import com.fjuul.sdk.android.exampleapp.R
 import com.fjuul.sdk.analytics.entities.AggregationType
+import com.fjuul.sdk.android.exampleapp.R
 import java.time.LocalDate
 
 class AggregatedDailyStatsFragment : Fragment() {

--- a/android/ExampleApp/app/src/main/java/com/fjuul/sdk/android/exampleapp/ui/aggregated_daily_stats/AggregatedDailyStatsFragment.kt
+++ b/android/ExampleApp/app/src/main/java/com/fjuul/sdk/android/exampleapp/ui/aggregated_daily_stats/AggregatedDailyStatsFragment.kt
@@ -46,7 +46,7 @@ class AggregatedDailyStatsFragment : Fragment() {
 
         when (model.aggregation.value) {
             AggregationType.sum -> view.findViewById<RadioButton>(R.id.radio_sum).isChecked = true
-            AggregationType.avg -> view.findViewById<RadioButton>(R.id.radio_avg).isChecked = true
+            AggregationType.average -> view.findViewById<RadioButton>(R.id.radio_avg).isChecked = true
         }
 
         model.requestData()
@@ -110,7 +110,7 @@ class AggregatedDailyStatsFragment : Fragment() {
         radioGroup.setOnCheckedChangeListener { group, checkedId ->
             when (checkedId) {
                 R.id.radio_sum -> model.setAggregation(AggregationType.sum)
-                R.id.radio_avg -> model.setAggregation(AggregationType.avg)
+                R.id.radio_avg -> model.setAggregation(AggregationType.average)
             }
         }
     }

--- a/android/ExampleApp/app/src/main/java/com/fjuul/sdk/android/exampleapp/ui/aggregated_daily_stats/AggregatedDailyStatsViewModel.kt
+++ b/android/ExampleApp/app/src/main/java/com/fjuul/sdk/android/exampleapp/ui/aggregated_daily_stats/AggregatedDailyStatsViewModel.kt
@@ -1,5 +1,5 @@
 package com.fjuul.sdk.android.exampleapp.ui.aggregated_daily_stats
-
+import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -25,12 +25,15 @@ class AggregatedDailyStatsViewModel() : ViewModel() {
     val errorMessage: LiveData<String> = _errorMessage
 
     fun requestData() {
+        Log.d("xz", (_aggregation.value).toString())
         analyticsService.getAggregatedDailyStats(_startDate.value!!, _endDate.value!!, _aggregation.value!!)
             .enqueue { _, result ->
+                Log.d("rezzzzzzzult", result.toString())
                 if (result.isError) {
                     _errorMessage.postValue(result.error?.message)
                 } else {
                     _data.postValue(result.value!!)
+
                 }
             }
     }
@@ -47,6 +50,7 @@ class AggregatedDailyStatsViewModel() : ViewModel() {
 
     fun setAggregation(aggregation: AggregationType) {
         _aggregation.value = aggregation
+        requestData()
     }
 }
 

--- a/android/ExampleApp/app/src/main/java/com/fjuul/sdk/android/exampleapp/ui/aggregated_daily_stats/AggregatedDailyStatsViewModel.kt
+++ b/android/ExampleApp/app/src/main/java/com/fjuul/sdk/android/exampleapp/ui/aggregated_daily_stats/AggregatedDailyStatsViewModel.kt
@@ -1,0 +1,66 @@
+package com.fjuul.sdk.android.exampleapp.ui.aggregated_daily_stats
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.fjuul.sdk.analytics.entities.AggregatedDailyStats
+import com.fjuul.sdk.analytics.entities.AggregationType
+import com.fjuul.sdk.analytics.http.services.AnalyticsService
+import com.fjuul.sdk.android.exampleapp.data.model.ApiClientHolder
+import java.time.LocalDate
+
+class AggregatedDailyStatsViewModel() : ViewModel() {
+    private val analyticsService = AnalyticsService(ApiClientHolder.sdkClient)
+    private val _startDate = MutableLiveData<LocalDate>(LocalDate.now())
+    private val _endDate = MutableLiveData<LocalDate>(LocalDate.now())
+    private val _aggregation = MutableLiveData<AggregationType>(AggregationType.sum)
+    private val _data = MutableLiveData<AggregatedDailyStats>()
+    private val _errorMessage = MutableLiveData<String>()
+
+    val data: LiveData<AggregatedDailyStats> = _data
+    val startDate: LiveData<LocalDate> = _startDate
+    val endDate: LiveData<LocalDate> = _endDate
+    val aggregation: LiveData<AggregationType> = _aggregation
+    val errorMessage: LiveData<String> = _errorMessage
+
+    fun requestData() {
+        analyticsService.getAggregatedDailyStats(_startDate.value!!, _endDate.value!!, _aggregation.value!!)
+            .enqueue { _, result ->
+                if (result.isError) {
+                    _errorMessage.postValue(result.error?.message)
+                } else {
+                    _data.postValue(result.value!!)
+                }
+            }
+    }
+
+    fun setupDateRange(startDate: LocalDate? = null, endDate: LocalDate? = null) {
+        if (startDate != null) {
+            _startDate.value = startDate
+        }
+        if (endDate != null) {
+            _endDate.value = endDate
+        }
+        requestData()
+    }
+
+    fun setAggregation(aggregation: AggregationType) {
+        _aggregation.value = aggregation
+    }
+}
+
+/**
+ * ViewModel provider factory to instantiate AggregatedDailyStatsViewModel.
+ * Required given AggregatedDailyStatsViewModelFactory has a non-empty constructor
+ */
+class AggregatedDailyStatsViewModelFactory : ViewModelProvider.Factory {
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(AggregatedDailyStatsViewModel::class.java)) {
+            return AggregatedDailyStatsViewModel() as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}

--- a/android/ExampleApp/app/src/main/java/com/fjuul/sdk/android/exampleapp/ui/aggregated_daily_stats/AggregatedDailyStatsViewModel.kt
+++ b/android/ExampleApp/app/src/main/java/com/fjuul/sdk/android/exampleapp/ui/aggregated_daily_stats/AggregatedDailyStatsViewModel.kt
@@ -1,5 +1,5 @@
 package com.fjuul.sdk.android.exampleapp.ui.aggregated_daily_stats
-import android.util.Log
+
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -25,10 +25,8 @@ class AggregatedDailyStatsViewModel() : ViewModel() {
     val errorMessage: LiveData<String> = _errorMessage
 
     fun requestData() {
-        Log.d("xz", (_aggregation.value).toString())
         analyticsService.getAggregatedDailyStats(_startDate.value!!, _endDate.value!!, _aggregation.value!!)
             .enqueue { _, result ->
-                Log.d("rezzzzzzzult", result.toString())
                 if (result.isError) {
                     _errorMessage.postValue(result.error?.message)
                 } else {

--- a/android/ExampleApp/app/src/main/java/com/fjuul/sdk/android/exampleapp/ui/aggregated_daily_stats/AggregatedDailyStatsViewModel.kt
+++ b/android/ExampleApp/app/src/main/java/com/fjuul/sdk/android/exampleapp/ui/aggregated_daily_stats/AggregatedDailyStatsViewModel.kt
@@ -31,7 +31,6 @@ class AggregatedDailyStatsViewModel() : ViewModel() {
                     _errorMessage.postValue(result.error?.message)
                 } else {
                     _data.postValue(result.value!!)
-
                 }
             }
     }

--- a/android/ExampleApp/app/src/main/java/com/fjuul/sdk/android/exampleapp/ui/modules/ModulesFragment.kt
+++ b/android/ExampleApp/app/src/main/java/com/fjuul/sdk/android/exampleapp/ui/modules/ModulesFragment.kt
@@ -22,6 +22,7 @@ enum class ModuleItemName(val value: String) {
     ACTIVITY_SOURCES("Activity Sources"),
     GF_SYNC("Google Fit synchronization"),
     DAILY_STATS("Daily Stats"),
+    AGGREGATED_DAILY_STATS("Aggregated Daily Stats"),
     LOGOUT("Logout")
 }
 sealed class ModulesListItem()
@@ -54,6 +55,7 @@ class ModulesFragment : Fragment() {
             ModuleItem(ModuleItemName.GF_SYNC),
             ModulesSection("Analytics"),
             ModuleItem(ModuleItemName.DAILY_STATS),
+            ModuleItem(ModuleItemName.AGGREGATED_DAILY_STATS),
             ModulesSection("Exit"),
             ModuleItem(ModuleItemName.LOGOUT)
         )
@@ -65,6 +67,10 @@ class ModulesFragment : Fragment() {
                 when (pressedItem.name) {
                     ModuleItemName.DAILY_STATS -> {
                         val action = ModulesFragmentDirections.actionModulesFragmentToDailyStatsFragment()
+                        findNavController().navigate(action)
+                    }
+                    ModuleItemName.AGGREGATED_DAILY_STATS -> {
+                        val action = ModulesFragmentDirections.actionModulesFragmentToAggregatedDailyStatsFragment()
                         findNavController().navigate(action)
                     }
                     ModuleItemName.PROFILE -> {

--- a/android/ExampleApp/app/src/main/res/layout/fragment_aggregated_daily_stats.xml
+++ b/android/ExampleApp/app/src/main/res/layout/fragment_aggregated_daily_stats.xml
@@ -142,7 +142,7 @@
                     android:minHeight="?android:attr/listPreferredItemHeightSmall"
                     android:text="Aggregate"
                     android:textAppearance="?android:attr/textAppearanceListItemSmall" />
-            
+
                 <RadioGroup
                     android:id="@+id/aggregate_radio_group"
                     android:layout_width="match_parent"
@@ -163,13 +163,11 @@
                 </RadioGroup>
             </LinearLayout>
         </LinearLayout>
-
-        <include
-            android:id="@+id/results_section_text"
-            layout="@layout/section_list_item"
+        <View
+            android:id="@+id/divider_aggregate"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="sdasd"
+            android:layout_height="2dp"
+            android:background="?android:attr/listDivider"
             app:layout_constraintTop_toBottomOf="@id/aggregate_layout" />
 
         <TextView
@@ -180,7 +178,10 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/results_section_text" />
+            android:paddingStart="?android:attr/listPreferredItemPaddingStart"
+            android:paddingEnd="?android:attr/listPreferredItemPaddingEnd"
+            android:textAppearance="?android:attr/textAppearanceListItemSmall"
+            app:layout_constraintTop_toBottomOf="@id/divider_aggregate" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </FrameLayout>

--- a/android/ExampleApp/app/src/main/res/layout/fragment_aggregated_daily_stats.xml
+++ b/android/ExampleApp/app/src/main/res/layout/fragment_aggregated_daily_stats.xml
@@ -58,7 +58,7 @@
             <View
                 android:id="@+id/divider_from"
                 android:layout_width="match_parent"
-                android:layout_height="2dp"
+                android:layout_height="1dp"
                 android:layout_marginTop="5dp"
                 android:background="?android:attr/listDivider"
                 app:layout_constraintTop_toBottomOf="@id/from_text_inputs" />
@@ -113,9 +113,19 @@
                 android:layout_height="1dp"
                 android:background="?android:attr/listDivider"
                 app:layout_constraintTop_toBottomOf="@id/to_text_inputs" />
-            
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/aggregate_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/to_input_layout">
+
             <LinearLayout
-                android:id="@+id/to_text_inputs"
+                android:id="@+id/aggregate_inputs"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="horizontal"
@@ -161,7 +171,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="sdasd"
-            app:layout_constraintTop_toBottomOf="@id/to_input_layout" />
+            app:layout_constraintTop_toBottomOf="@id/aggregate_layout" />
 
         <TextView
             android:id="@+id/aggregated_stats"

--- a/android/ExampleApp/app/src/main/res/layout/fragment_aggregated_daily_stats.xml
+++ b/android/ExampleApp/app/src/main/res/layout/fragment_aggregated_daily_stats.xml
@@ -158,7 +158,7 @@
                     <RadioButton android:id="@+id/radio_avg"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="avg"
+                        android:text="average"
                         android:layout_weight="1"/>
                 </RadioGroup>
             </LinearLayout>

--- a/android/ExampleApp/app/src/main/res/layout/fragment_aggregated_daily_stats.xml
+++ b/android/ExampleApp/app/src/main/res/layout/fragment_aggregated_daily_stats.xml
@@ -125,7 +125,6 @@
             app:layout_constraintTop_toBottomOf="@id/to_input_layout">
 
             <LinearLayout
-                android:id="@+id/aggregate_inputs"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="horizontal"
@@ -145,6 +144,7 @@
                     android:textAppearance="?android:attr/textAppearanceListItemSmall" />
             
                 <RadioGroup
+                    android:id="@+id/aggregate_radio_group"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:orientation="horizontal"
@@ -154,13 +154,12 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="sum"
-                        android:paddingEnd="?android:attr/listPreferredItemPaddingEnd"
-                        android:onClick="onRadioButtonClicked"/>
+                        android:layout_weight="1"/>
                     <RadioButton android:id="@+id/radio_avg"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="avg"
-                        android:onClick="onRadioButtonClicked"/>
+                        android:layout_weight="1"/>
                 </RadioGroup>
             </LinearLayout>
         </LinearLayout>

--- a/android/ExampleApp/app/src/main/res/layout/fragment_aggregated_daily_stats.xml
+++ b/android/ExampleApp/app/src/main/res/layout/fragment_aggregated_daily_stats.xml
@@ -1,0 +1,177 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.aggregated_daily_stats.AggregatedDailyStatsFragment">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="horizontal"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <LinearLayout
+            android:id="@+id/from_input_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <LinearLayout
+                android:id="@+id/from_text_inputs"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingStart="?android:attr/listPreferredItemPaddingStart"
+                android:paddingEnd="?android:attr/listPreferredItemPaddingEnd"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent">
+
+                <TextView
+                    android:id="@+id/textView"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:ems="10"
+                    android:gravity="center_vertical"
+                    android:minHeight="?android:attr/listPreferredItemHeightSmall"
+                    android:text="From"
+                    android:textAppearance="?android:attr/textAppearanceListItemSmall"
+                    app:layout_constraintLeft_toLeftOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <TextView
+                    android:id="@+id/from_value_text"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:ems="10"
+                    android:text="7/22/20"
+                    android:textAlignment="viewEnd"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintRight_toRightOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+            </LinearLayout>
+
+            <View
+                android:id="@+id/divider_from"
+                android:layout_width="match_parent"
+                android:layout_height="2dp"
+                android:layout_marginTop="5dp"
+                android:background="?android:attr/listDivider"
+                app:layout_constraintTop_toBottomOf="@id/from_text_inputs" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/to_input_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/from_input_layout">
+
+            <LinearLayout
+                android:id="@+id/to_text_inputs"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:paddingStart="?android:attr/listPreferredItemPaddingStart"
+                android:paddingEnd="?android:attr/listPreferredItemPaddingEnd"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:ems="10"
+                    android:gravity="center_vertical"
+                    android:minHeight="?android:attr/listPreferredItemHeightSmall"
+                    android:text="To"
+                    android:textAppearance="?android:attr/textAppearanceListItemSmall"
+                    app:layout_constraintLeft_toLeftOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <TextView
+                    android:id="@+id/to_value_text"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:ems="10"
+                    android:text="7/22/20"
+                    android:textAlignment="viewEnd"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintRight_toRightOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+            </LinearLayout>
+
+            <View
+                android:id="@+id/divider_to"
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:background="?android:attr/listDivider"
+                app:layout_constraintTop_toBottomOf="@id/to_text_inputs" />
+            
+            <LinearLayout
+                android:id="@+id/to_text_inputs"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:paddingStart="?android:attr/listPreferredItemPaddingStart"
+                android:paddingEnd="?android:attr/listPreferredItemPaddingEnd"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:ems="10"
+                    android:gravity="center_vertical"
+                    android:minHeight="?android:attr/listPreferredItemHeightSmall"
+                    android:text="Aggregate"
+                    android:textAppearance="?android:attr/textAppearanceListItemSmall" />
+            
+                <RadioGroup
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:paddingStart="?android:attr/listPreferredItemPaddingStart"
+                    android:paddingEnd="?android:attr/listPreferredItemPaddingEnd">
+                    <RadioButton android:id="@+id/radio_sum"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="sum"
+                        android:paddingEnd="?android:attr/listPreferredItemPaddingEnd"
+                        android:onClick="onRadioButtonClicked"/>
+                    <RadioButton android:id="@+id/radio_avg"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="avg"
+                        android:onClick="onRadioButtonClicked"/>
+                </RadioGroup>
+            </LinearLayout>
+        </LinearLayout>
+
+        <include
+            android:id="@+id/results_section_text"
+            layout="@layout/section_list_item"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="sdasd"
+            app:layout_constraintTop_toBottomOf="@id/to_input_layout" />
+
+        <TextView
+            android:id="@+id/aggregated_stats"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_marginTop="10dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/results_section_text" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</FrameLayout>

--- a/android/ExampleApp/app/src/main/res/navigation/nav_graph.xml
+++ b/android/ExampleApp/app/src/main/res/navigation/nav_graph.xml
@@ -25,6 +25,9 @@
             android:id="@+id/action_modulesFragment_to_dailyStatsFragment"
             app:destination="@id/dailyStatsFragment" />
         <action
+            android:id="@+id/action_modulesFragment_to_aggregatedDailyStatsFragment"
+            app:destination="@id/aggregatedDailyStatsFragment" />
+        <action
             android:id="@+id/action_modulesFragment_to_userProfileFragment"
             app:destination="@id/userProfileFragment" />
         <action
@@ -39,6 +42,11 @@
         android:name="com.fjuul.sdk.android.exampleapp.ui.daily_stats.DailyStatsFragment"
         android:label="Daily Stats"
         tools:layout="@layout/fragment_daily_stats" />
+    <fragment
+        android:id="@+id/aggregatedDailyStatsFragment"
+        android:name="com.fjuul.sdk.android.exampleapp.ui.aggregated_daily_stats.AggregatedDailyStatsFragment"
+        android:label="Aggregated Daily Stats"
+        tools:layout="@layout/fragment_aggregated_daily_stats" />
     <fragment
         android:id="@+id/userProfileFragment"
         android:name="com.fjuul.sdk.android.exampleapp.ui.user_profile.UserProfileFragment"

--- a/android/analytics/src/main/java/com/fjuul/sdk/analytics/entities/AggregatedDailyStats.java
+++ b/android/analytics/src/main/java/com/fjuul/sdk/analytics/entities/AggregatedDailyStats.java
@@ -1,0 +1,41 @@
+package com.fjuul.sdk.analytics.entities;
+
+import androidx.annotation.NonNull;
+
+public class AggregatedDailyStats {
+
+    float activeKcal;
+    float bmr;
+
+    @NonNull
+    ActivityMeasure low;
+    @NonNull
+    ActivityMeasure moderate;
+    @NonNull
+    ActivityMeasure high;
+
+    @NonNull
+    public float getActiveKcal() {
+        return activeKcal;
+    }
+
+    @NonNull
+    public float getBmr() {
+        return bmr;
+    }
+
+    @NonNull
+    public ActivityMeasure getLow() {
+        return low;
+    }
+
+    @NonNull
+    public ActivityMeasure getModerate() {
+        return moderate;
+    }
+
+    @NonNull
+    public ActivityMeasure getHigh() {
+        return high;
+    }
+}

--- a/android/analytics/src/main/java/com/fjuul/sdk/analytics/entities/AggregationType.java
+++ b/android/analytics/src/main/java/com/fjuul/sdk/analytics/entities/AggregationType.java
@@ -1,0 +1,6 @@
+package com.fjuul.sdk.analytics.entities;
+
+public enum AggregationType {
+  sum,
+  avg
+}

--- a/android/analytics/src/main/java/com/fjuul/sdk/analytics/entities/AggregationType.java
+++ b/android/analytics/src/main/java/com/fjuul/sdk/analytics/entities/AggregationType.java
@@ -2,5 +2,5 @@ package com.fjuul.sdk.analytics.entities;
 
 public enum AggregationType {
     sum,
-    avg
+    average
 }

--- a/android/analytics/src/main/java/com/fjuul/sdk/analytics/entities/AggregationType.java
+++ b/android/analytics/src/main/java/com/fjuul/sdk/analytics/entities/AggregationType.java
@@ -1,6 +1,6 @@
 package com.fjuul.sdk.analytics.entities;
 
 public enum AggregationType {
-  sum,
-  avg
+    sum,
+    avg
 }

--- a/android/analytics/src/main/java/com/fjuul/sdk/analytics/http/apis/AnalyticsApi.java
+++ b/android/analytics/src/main/java/com/fjuul/sdk/analytics/http/apis/AnalyticsApi.java
@@ -1,6 +1,7 @@
 package com.fjuul.sdk.analytics.http.apis;
 
 import com.fjuul.sdk.analytics.entities.DailyStats;
+import com.fjuul.sdk.analytics.entities.AggregatedDailyStats;
 import com.fjuul.sdk.core.http.utils.ApiCall;
 
 import androidx.annotation.NonNull;
@@ -18,4 +19,11 @@ public interface AnalyticsApi {
     ApiCall<DailyStats[]> getDailyStats(@Path("userToken") @NonNull String userToken,
         @Query("from") @NonNull String startDate,
         @Query("to") @NonNull String endDate);
+
+    @GET("/sdk/analytics/v1/daily-stats/{userToken}/aggregated")
+    @NonNull
+    ApiCall<AggregatedDailyStats> getAggregatedDailyStats(@Path("userToken") @NonNull String userToken,
+        @Query("from") @NonNull String startDate,
+        @Query("to") @NonNull String endDate,
+        @Query("aggregation") @NonNull String aggregation);
 }

--- a/android/analytics/src/main/java/com/fjuul/sdk/analytics/http/apis/AnalyticsApi.java
+++ b/android/analytics/src/main/java/com/fjuul/sdk/analytics/http/apis/AnalyticsApi.java
@@ -1,7 +1,7 @@
 package com.fjuul.sdk.analytics.http.apis;
 
-import com.fjuul.sdk.analytics.entities.DailyStats;
 import com.fjuul.sdk.analytics.entities.AggregatedDailyStats;
+import com.fjuul.sdk.analytics.entities.DailyStats;
 import com.fjuul.sdk.core.http.utils.ApiCall;
 
 import androidx.annotation.NonNull;

--- a/android/analytics/src/main/java/com/fjuul/sdk/analytics/http/services/AnalyticsService.java
+++ b/android/analytics/src/main/java/com/fjuul/sdk/analytics/http/services/AnalyticsService.java
@@ -72,7 +72,7 @@ public class AnalyticsService {
      *        the users local timezone.
      * @param endDate the end of the interval to request daily stats aggregate for (inclusive); this is the date in the
      *        users local timezone.
-     * @param aggregation aggregation type; sum or avg.
+     * @param aggregation aggregation type; sum or average.
      * @return ApiCall for the user activity statistics for the given day interval.
      */
     public @NonNull ApiCall<AggregatedDailyStats> getAggregatedDailyStats(@NonNull LocalDate startDate,

--- a/android/analytics/src/main/java/com/fjuul/sdk/analytics/http/services/AnalyticsService.java
+++ b/android/analytics/src/main/java/com/fjuul/sdk/analytics/http/services/AnalyticsService.java
@@ -3,9 +3,9 @@ package com.fjuul.sdk.analytics.http.services;
 import java.time.LocalDate;
 import java.util.Date;
 
-import com.fjuul.sdk.analytics.entities.DailyStats;
 import com.fjuul.sdk.analytics.entities.AggregatedDailyStats;
 import com.fjuul.sdk.analytics.entities.AggregationType;
+import com.fjuul.sdk.analytics.entities.DailyStats;
 import com.fjuul.sdk.analytics.http.apis.AnalyticsApi;
 import com.fjuul.sdk.core.ApiClient;
 import com.fjuul.sdk.core.http.utils.ApiCall;
@@ -68,14 +68,19 @@ public class AnalyticsService {
     /**
      * Builds a call to get sums or averages of the daily activity statistics within a given date range.
      *
-     * @param startDate the start of the interval to request daily stats aggregate for (inclusive); this is the date in the
+     * @param startDate the start of the interval to request daily stats aggregate for (inclusive); this is the date in
+     *        the users local timezone.
+     * @param endDate the end of the interval to request daily stats aggregate for (inclusive); this is the date in the
      *        users local timezone.
-     * @param endDate the end of the interval to request daily stats aggregate for (inclusive); this is the date in the users
-     *        local timezone.
      * @param aggregation aggregation type; sum or avg.
      * @return ApiCall for the user activity statistics for the given day interval.
      */
-    public @NonNull ApiCall<AggregatedDailyStats> getAggregatedDailyStats(@NonNull LocalDate startDate, @NonNull LocalDate endDate, @NonNull AggregationType aggregation) {
-        return analyticsApiClient.getAggregatedDailyStats(clientBuilder.getUserToken(), startDate.toString(), endDate.toString(), aggregation.toString());
+    public @NonNull ApiCall<AggregatedDailyStats> getAggregatedDailyStats(@NonNull LocalDate startDate,
+        @NonNull LocalDate endDate,
+        @NonNull AggregationType aggregation) {
+        return analyticsApiClient.getAggregatedDailyStats(clientBuilder.getUserToken(),
+            startDate.toString(),
+            endDate.toString(),
+            aggregation.toString());
     }
 }

--- a/android/analytics/src/main/java/com/fjuul/sdk/analytics/http/services/AnalyticsService.java
+++ b/android/analytics/src/main/java/com/fjuul/sdk/analytics/http/services/AnalyticsService.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.Date;
 
 import com.fjuul.sdk.analytics.entities.DailyStats;
+import com.fjuul.sdk.analytics.entities.AggregatedDailyStats;
 import com.fjuul.sdk.analytics.http.apis.AnalyticsApi;
 import com.fjuul.sdk.core.ApiClient;
 import com.fjuul.sdk.core.http.utils.ApiCall;
@@ -62,4 +63,23 @@ public class AnalyticsService {
     public @NonNull ApiCall<DailyStats[]> getDailyStats(@NonNull LocalDate startDate, @NonNull LocalDate endDate) {
         return analyticsApiClient.getDailyStats(clientBuilder.getUserToken(), startDate.toString(), endDate.toString());
     }
+
+    /**
+     * Builds a call to get sums or averages of the daily activity statistics within a given date range.
+     *
+     * @param startDate the start of the interval to request daily stats aggregate for (inclusive); this is the date in the
+     *        users local timezone.
+     * @param endDate the end of the interval to request daily stats aggregate for (inclusive); this is the date in the users
+     *        local timezone.
+     * @param aggregation aggregation type; sum or avg.
+     * @return ApiCall for the user activity statistics for the given day interval.
+     */
+    public @NonNull ApiCall<AggregatedDailyStats> getAggregatedDailyStats(@NonNull LocalDate startDate, @NonNull LocalDate endDate, @NonNull AggregationType aggregation) {
+        return analyticsApiClient.getAggregatedDailyStats(clientBuilder.getUserToken(), startDate.toString(), endDate.toString(), aggregation.toString());
+    }
+}
+
+enum AggregationType {
+    sum,
+    avg
 }

--- a/android/analytics/src/main/java/com/fjuul/sdk/analytics/http/services/AnalyticsService.java
+++ b/android/analytics/src/main/java/com/fjuul/sdk/analytics/http/services/AnalyticsService.java
@@ -5,6 +5,7 @@ import java.util.Date;
 
 import com.fjuul.sdk.analytics.entities.DailyStats;
 import com.fjuul.sdk.analytics.entities.AggregatedDailyStats;
+import com.fjuul.sdk.analytics.entities.AggregationType;
 import com.fjuul.sdk.analytics.http.apis.AnalyticsApi;
 import com.fjuul.sdk.core.ApiClient;
 import com.fjuul.sdk.core.http.utils.ApiCall;
@@ -77,9 +78,4 @@ public class AnalyticsService {
     public @NonNull ApiCall<AggregatedDailyStats> getAggregatedDailyStats(@NonNull LocalDate startDate, @NonNull LocalDate endDate, @NonNull AggregationType aggregation) {
         return analyticsApiClient.getAggregatedDailyStats(clientBuilder.getUserToken(), startDate.toString(), endDate.toString(), aggregation.toString());
     }
-}
-
-enum AggregationType {
-    sum,
-    avg
 }

--- a/android/analytics/src/test/java/com/fjuul/sdk/analytics/http/services/AnalyticsServiceTest.java
+++ b/android/analytics/src/test/java/com/fjuul/sdk/analytics/http/services/AnalyticsServiceTest.java
@@ -30,7 +30,6 @@ import com.fjuul.sdk.core.http.utils.ApiCallResult;
 import com.fjuul.sdk.test.http.TestApiClient;
 
 import android.os.Build;
-
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -164,10 +163,9 @@ public class AnalyticsServiceTest {
                 + "\"high\": { \"seconds\": 600, \"metMinutes\": 9 }\n" + "}");
         mockWebServer.enqueue(mockResponse);
 
-        ApiCallResult<AggregatedDailyStats> result =
-            analyticsService.getAggregatedDailyStats(LocalDate.parse("2020-03-10"),
-                LocalDate.parse("2020-03-11"),
-                AggregationType.sum).execute();
+        ApiCallResult<AggregatedDailyStats> result = analyticsService
+            .getAggregatedDailyStats(LocalDate.parse("2020-03-10"), LocalDate.parse("2020-03-11"), AggregationType.sum)
+            .execute();
 
         RecordedRequest request = mockWebServer.takeRequest();
         assertThat("should transform local date to string",

--- a/android/analytics/src/test/java/com/fjuul/sdk/analytics/http/services/AnalyticsServiceTest.java
+++ b/android/analytics/src/test/java/com/fjuul/sdk/analytics/http/services/AnalyticsServiceTest.java
@@ -17,6 +17,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import com.fjuul.sdk.analytics.entities.AggregatedDailyStats;
+import com.fjuul.sdk.analytics.entities.AggregationType;
 import com.fjuul.sdk.analytics.entities.DailyStats;
 import com.fjuul.sdk.core.entities.InMemoryStorage;
 import com.fjuul.sdk.core.entities.Keystore;
@@ -29,6 +30,7 @@ import com.fjuul.sdk.core.http.utils.ApiCallResult;
 import com.fjuul.sdk.test.http.TestApiClient;
 
 import android.os.Build;
+
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -156,14 +158,16 @@ public class AnalyticsServiceTest {
         analyticsService = new AnalyticsService(clientBuilder.build());
         MockResponse mockResponse = new MockResponse().setResponseCode(HttpURLConnection.HTTP_OK)
             .setHeader("Content-Type", "application/json")
-            .setBody("{\n" + "" + "\"activeKcal\": 170.14,\n" + "\"bmr\": 860.16,\n"
+            .setBody("{\n" + "\"activeKcal\": 170.14,\n" + "\"bmr\": 860.16,\n"
                 + "\"low\": { \"seconds\": 2222, \"metMinutes\": 32 },\n"
                 + "\"moderate\": { \"seconds\": 1980, \"metMinutes\": 44 },\n"
                 + "\"high\": { \"seconds\": 600, \"metMinutes\": 9 }\n" + "}");
         mockWebServer.enqueue(mockResponse);
 
         ApiCallResult<AggregatedDailyStats> result =
-            analyticsService.getAggregatedDailyStats(LocalDate.parse("2020-03-10"), LocalDate.parse("2020-03-11"), AggregationType.sum).execute();
+            analyticsService.getAggregatedDailyStats(LocalDate.parse("2020-03-10"),
+                LocalDate.parse("2020-03-11"),
+                AggregationType.sum).execute();
 
         RecordedRequest request = mockWebServer.takeRequest();
         assertThat("should transform local date to string",

--- a/android/analytics/src/test/java/com/fjuul/sdk/analytics/http/services/AnalyticsServiceTest.java
+++ b/android/analytics/src/test/java/com/fjuul/sdk/analytics/http/services/AnalyticsServiceTest.java
@@ -16,6 +16,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
+import com.fjuul.sdk.analytics.entities.AggregatedDailyStats;
 import com.fjuul.sdk.analytics.entities.DailyStats;
 import com.fjuul.sdk.core.entities.InMemoryStorage;
 import com.fjuul.sdk.core.entities.Keystore;
@@ -146,6 +147,40 @@ public class AnalyticsServiceTest {
         assertEquals(120, secondDailyStats.getModerate().getSeconds(), 0.0001);
         assertEquals(3.4, secondDailyStats.getHigh().getMetMinutes(), 0.0001);
         assertEquals(30, secondDailyStats.getHigh().getSeconds(), 0.0001);
+    }
+
+    @Test
+    public void getAggregatedDailyStatsTest() throws InterruptedException {
+        testKeystore.setKey(validSigningKey);
+        clientBuilder.setKeystore(testKeystore);
+        analyticsService = new AnalyticsService(clientBuilder.build());
+        MockResponse mockResponse = new MockResponse().setResponseCode(HttpURLConnection.HTTP_OK)
+            .setHeader("Content-Type", "application/json")
+            .setBody("{\n" + "" + "\"activeKcal\": 170.14,\n" + "\"bmr\": 860.16,\n"
+                + "\"low\": { \"seconds\": 2222, \"metMinutes\": 32 },\n"
+                + "\"moderate\": { \"seconds\": 1980, \"metMinutes\": 44 },\n"
+                + "\"high\": { \"seconds\": 600, \"metMinutes\": 9 }\n" + "}");
+        mockWebServer.enqueue(mockResponse);
+
+        ApiCallResult<AggregatedDailyStats> result =
+            analyticsService.getAggregatedDailyStats(LocalDate.parse("2020-03-10"), LocalDate.parse("2020-03-11"), AggregationType.sum).execute();
+
+        RecordedRequest request = mockWebServer.takeRequest();
+        assertThat("should transform local date to string",
+            request.getPath(),
+            containsString("daily-stats/USER_TOKEN/aggregated?from=2020-03-10&to=2020-03-11&aggregation=sum"));
+
+        assertFalse("success result", result.isError());
+        AggregatedDailyStats aggregatedStats = result.getValue();
+
+        assertEquals(170.14, aggregatedStats.getActiveKcal(), 0.0001);
+        assertEquals(860.16, aggregatedStats.getBmr(), 0.0001);
+        assertEquals(32, aggregatedStats.getLow().getMetMinutes(), 0.0001);
+        assertEquals(2222, aggregatedStats.getLow().getSeconds(), 0.0001);
+        assertEquals(44, aggregatedStats.getModerate().getMetMinutes(), 0.0001);
+        assertEquals(1980, aggregatedStats.getModerate().getSeconds(), 0.0001);
+        assertEquals(9, aggregatedStats.getHigh().getMetMinutes(), 0.0001);
+        assertEquals(600, aggregatedStats.getHigh().getSeconds(), 0.0001);
     }
 
     @Test

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip

--- a/docs/android-examples.md
+++ b/docs/android-examples.md
@@ -234,7 +234,7 @@ dailyStats.forEach { item ->
 import com.fjuul.sdk.analytics.http.services.AnalyticsService
 ...
 val analyticsService = AnalyticsService(signedClient)
-val getAggregatedDailyStatsApiCall = analyticsService.getAggregatedDailyStats("2020-10-03", "2020-10-20", "sum")
+val getAggregatedDailyStatsApiCall = analyticsService.getAggregatedDailyStats("2020-10-03", "2020-10-20", AggregationType.sum)
 val getAggregatedDailyStatsApiResult = getAggregatedDailyStatsApiCall.execute()
 if (getAggregatedDailyStatsApiResult.isError) {
     // handle error

--- a/docs/android-examples.md
+++ b/docs/android-examples.md
@@ -229,6 +229,26 @@ dailyStats.forEach { item ->
 }
 ```
 
+### Getting sum or average aggregates of DailyStats per time interval
+```kotlin
+import com.fjuul.sdk.analytics.http.services.AnalyticsService
+...
+val analyticsService = AnalyticsService(signedClient)
+val getAggregatedDailyStatsApiCall = analyticsService.getAggregatedDailyStats("2020-10-03", "2020-10-20", "sum")
+val getAggregatedDailyStatsApiResult = getAggregatedDailyStatsApiCall.execute()
+if (getAggregatedDailyStatsApiResult.isError) {
+    // handle error
+}
+val statsSums = getDailyStatsApiResult.value!!
+statsSums.forEach { item ->
+    val formattedItem = """
+        |low: ${item.low.metMinutes} metMinutes;
+        |moderate: ${item.moderate.metMinutes} metMinutes;
+        |high: ${item.high.metMinutes} metMinutes""".trimMargin()
+        println(formattedItem)
+}
+```
+
 ## Logging
 Fjuul SDK uses [Timber](https://github.com/JakeWharton/timber) for logging internal events and exposes this dependency to consumers.<br/>
 For ordinary debugging, you can use `DebugTimberTree` that writes everything from Fjuul SDK to the standard android's Log:

--- a/docs/android-examples.md
+++ b/docs/android-examples.md
@@ -213,7 +213,7 @@ ActivitySourcesManager.initialize(client, config)
 import com.fjuul.sdk.analytics.http.services.AnalyticsService
 ...
 val analyticsService = AnalyticsService(signedClient)
-val getDailyStatsApiCall = analyticsService.getDailyStats("2020-10-03", "2020-10-20")
+val getDailyStatsApiCall = analyticsService.getDailyStats(LocalDate.parse("2020-10-03"), LocalDate.parse("2020-10-20"))
 val getDailyStatsApiResult = getDailyStatsApiCall.execute()
 if (getDailyStatsApiResult.isError) {
     // handle error
@@ -234,7 +234,7 @@ dailyStats.forEach { item ->
 import com.fjuul.sdk.analytics.http.services.AnalyticsService
 ...
 val analyticsService = AnalyticsService(signedClient)
-val getAggregatedDailyStatsApiCall = analyticsService.getAggregatedDailyStats("2020-10-03", "2020-10-20", AggregationType.sum)
+val getAggregatedDailyStatsApiCall = analyticsService.getAggregatedDailyStats(LocalDate.parse("2020-10-03"), LocalDate.parse.("2020-10-20"), AggregationType.sum)
 val getAggregatedDailyStatsApiResult = getAggregatedDailyStatsApiCall.execute()
 if (getAggregatedDailyStatsApiResult.isError) {
     // handle error

--- a/docs/ios-examples.md
+++ b/docs/ios-examples.md
@@ -212,3 +212,28 @@ apiClient.analytics.dailyStats(from: fromDate, to: toDate) { result in
     }
 }
 ```
+
+### Get sum or average aggregates of DailyStats per time interval
+
+``` swift
+import FjuulAnalytics
+
+let fromDate = Calendar.current.date(byAdding: .day, value: -7, to: Date())
+let toDate = Date()
+
+apiClient.analytics.dailyStatsAggregate(from: fromDate, to: toDate, aggregation: "avg") { result in
+    switch result {
+    case .success(let statsAvgs):
+        // returns an object of daily stats' averages for requested period
+        //{
+        //    "activeKcal": 300,
+        //    "bmr": 1700,
+        //    "low": { "seconds": 1800, "metMinutes": 20 },
+        //    "moderate": { "seconds": 1200, "metMinutes": 10 },
+        //    "high": { "seconds": 180, "metMinutes": 15 },
+        //}
+    case .failure(let err):
+        // handle error
+    }
+}
+```

--- a/docs/ios-examples.md
+++ b/docs/ios-examples.md
@@ -221,7 +221,7 @@ import FjuulAnalytics
 let fromDate = Calendar.current.date(byAdding: .day, value: -7, to: Date())
 let toDate = Date()
 
-apiClient.analytics.dailyStatsAggregate(from: fromDate, to: toDate, aggregation: AggregationType.average) { result in
+apiClient.analytics.aggregatedDailyStats(from: fromDate, to: toDate, aggregation: AggregationType.average) { result in
     switch result {
     case .success(let statsAvgs):
         // returns an object of daily stats' averages for requested period

--- a/docs/ios-examples.md
+++ b/docs/ios-examples.md
@@ -221,7 +221,7 @@ import FjuulAnalytics
 let fromDate = Calendar.current.date(byAdding: .day, value: -7, to: Date())
 let toDate = Date()
 
-apiClient.analytics.dailyStatsAggregate(from: fromDate, to: toDate, aggregation: "avg") { result in
+apiClient.analytics.dailyStatsAggregate(from: fromDate, to: toDate, aggregation: AggregationType.average) { result in
     switch result {
     case .success(let statsAvgs):
         // returns an object of daily stats' averages for requested period

--- a/ios/ActivitySources/Tests/ActivitySourceManagerTests.swift
+++ b/ios/ActivitySources/Tests/ActivitySourceManagerTests.swift
@@ -88,12 +88,12 @@ final class ActivitySourcesManagerTests: XCTestCase {
         let healthKitMock = MountableHealthKitActivitySourceMock()
         Given(healthKitMock, .trackerValue(getter: TrackerValue.HEALTHKIT))
 
-        Perform(apiClientMock, .connect(trackerValue: .value(TrackerValue.HEALTHKIT), completion: .any, perform: { (item, completion) in
+        Perform(apiClientMock, .connect(trackerValue: .value(TrackerValue.HEALTHKIT), completion: .any, perform: { (_, completion) in
             let trackerConnection = TrackerConnection(id: "0ca60422-3626-4b50-aa70-43c91d8da731", tracker: "healthkit", createdAt: Date(), endedAt: nil)
             completion(.success(.connected(trackerConnection: trackerConnection)))
         }))
 
-        Perform(healthKitMock, .requestAccess(config: .any, completion: .any, perform: { (item, completion) in
+        Perform(healthKitMock, .requestAccess(config: .any, completion: .any, perform: { (_, completion) in
            completion(.success(()))
         }))
 
@@ -123,7 +123,7 @@ final class ActivitySourcesManagerTests: XCTestCase {
         let promise = expectation(description: "Success get external authentication URL")
 
         let polarAuthUrl = "https://flow.polar.com/oauth2/authorization?response_type=code&client_id=71fyfQ"
-        Perform(apiClientMock, .connect(trackerValue: .value(TrackerValue.POLAR), completion: .any, perform: { (item, completion) in
+        Perform(apiClientMock, .connect(trackerValue: .value(TrackerValue.POLAR), completion: .any, perform: { (_, completion) in
 
             completion(.success(.externalAuthenticationFlowRequired(authenticationUrl: polarAuthUrl)))
         }))
@@ -150,7 +150,7 @@ final class ActivitySourcesManagerTests: XCTestCase {
         // Given
         let promise = expectation(description: "Handle server response with error")
 
-        Perform(apiClientMock, .connect(trackerValue: .value(TrackerValue.POLAR), completion: .any, perform: { (item, completion) in
+        Perform(apiClientMock, .connect(trackerValue: .value(TrackerValue.POLAR), completion: .any, perform: { (_, completion) in
             completion(.failure(FjuulError.activitySourceConnectionFailure(reason: .sourceAlreadyConnected(message: "Conflict, the source already connected"))))
         }))
 
@@ -178,7 +178,7 @@ final class ActivitySourcesManagerTests: XCTestCase {
         let trackerConnection = TrackerConnection(id: "0ca60422", tracker: "polar", createdAt: Date(), endedAt: nil)
         let activitySourceConnection = ActivitySourceConnection(trackerConnection: trackerConnection, activitySource: PolarActivitySource.shared)
 
-        Perform(apiClientMock, .disconnect(activitySourceConnection: .value(activitySourceConnection), completion: .any, perform: { (item, completion) in
+        Perform(apiClientMock, .disconnect(activitySourceConnection: .value(activitySourceConnection), completion: .any, perform: { (_, completion) in
 
             completion(.success(()))
         }))
@@ -202,7 +202,7 @@ final class ActivitySourcesManagerTests: XCTestCase {
         let trackerConnection = TrackerConnection(id: "0ca60422", tracker: "polar", createdAt: Date(), endedAt: nil)
         let activitySourceConnection = ActivitySourceConnection(trackerConnection: trackerConnection, activitySource: PolarActivitySource.shared)
 
-        Perform(apiClientMock, .disconnect(activitySourceConnection: .value(activitySourceConnection), completion: .any, perform: { (item, completion) in
+        Perform(apiClientMock, .disconnect(activitySourceConnection: .value(activitySourceConnection), completion: .any, perform: { (_, completion) in
 
             completion(.failure(FjuulError.invalidConfig))
         }))

--- a/ios/Analytics/Sources/AggregatedDailyStats.swift
+++ b/ios/Analytics/Sources/AggregatedDailyStats.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+public struct AggregatedDailyStats: Codable {
+
+    public let activeKcal: Float
+    public let bmr: Float
+
+    public let low: ActivityMeasure
+    public let moderate: ActivityMeasure
+    public let high: ActivityMeasure
+
+}

--- a/ios/Analytics/Sources/AnalyticsApi.swift
+++ b/ios/Analytics/Sources/AnalyticsApi.swift
@@ -83,7 +83,7 @@ public class AnalyticsApi {
         let parameters = [
             "from": DateFormatters.yyyyMMddLocale.string(from: from),
             "to": DateFormatters.yyyyMMddLocale.string(from: to),
-            "aggregation": aggregation,
+            "aggregation": aggregation.rawValue,
         ]
         apiClient.signedSession.request(url, method: .get, parameters: parameters).apiResponse { response in
             let decodedResponse = response
@@ -116,6 +116,5 @@ public extension ApiClient {
 }
 
 public enum AggregationType: String {
-    sum,
-    avg
+    case sum, avg
 }

--- a/ios/Analytics/Sources/AnalyticsApi.swift
+++ b/ios/Analytics/Sources/AnalyticsApi.swift
@@ -73,7 +73,7 @@ public class AnalyticsApi {
     /// - Parameters:
     ///   - from: The start of the day interval to requests daily stats for (inclusive).
     ///   - to: The end of the day interval to request daily stats for (inclusive).
-    ///   - aggregation: The aggregate type: sum or avg.
+    ///   - aggregation: The aggregate type: sum or average.
     ///   - completion: The code to be executed once the request has finished.
     public func dailyStatsAggregate(from: Date, to: Date, aggregation: AggregationType, completion: @escaping (Result<AggregatedDailyStats, Error>) -> Void) {
         let path = "/daily-stats/\(apiClient.userToken)/aggregated"
@@ -116,5 +116,5 @@ public extension ApiClient {
 }
 
 public enum AggregationType: String, CaseIterable {
-    case sum, avg
+    case sum, average
 }

--- a/ios/Analytics/Sources/AnalyticsApi.swift
+++ b/ios/Analytics/Sources/AnalyticsApi.swift
@@ -75,7 +75,7 @@ public class AnalyticsApi {
     ///   - to: The end of the day interval to request daily stats for (inclusive).
     ///   - aggregation: The aggregate type: sum or average.
     ///   - completion: The code to be executed once the request has finished.
-    public func dailyStatsAggregate(from: Date, to: Date, aggregation: AggregationType, completion: @escaping (Result<AggregatedDailyStats, Error>) -> Void) {
+    public func aggregatedDailyStats(from: Date, to: Date, aggregation: AggregationType, completion: @escaping (Result<AggregatedDailyStats, Error>) -> Void) {
         let path = "/daily-stats/\(apiClient.userToken)/aggregated"
         guard let url = baseUrl?.appendingPathComponent(path) else {
             return completion(.failure(FjuulError.invalidConfig))

--- a/ios/Analytics/Sources/AnalyticsApi.swift
+++ b/ios/Analytics/Sources/AnalyticsApi.swift
@@ -115,6 +115,6 @@ public extension ApiClient {
 
 }
 
-public enum AggregationType: String {
+public enum AggregationType: String, CaseIterable {
     case sum, avg
 }

--- a/ios/Analytics/Tests/AnalyticsApiTests.swift
+++ b/ios/Analytics/Tests/AnalyticsApiTests.swift
@@ -25,7 +25,7 @@ final class AnalyticsApiTests: XCTestCase {
             \"bmr\":1755.64,\"activeKcal\":755.64,\"steps\":10000
         }
     """
-    
+
     let aggregatedDailyStatsResponse = """
         {
             \"low\":{\"seconds\":80,\"metMinutes\":4.44},
@@ -97,7 +97,7 @@ final class AnalyticsApiTests: XCTestCase {
         }
         waitForExpectations(timeout: 5.0, handler: nil)
     }
-    
+
     func testGetAggregatedDailyStats() {
         let e = expectation(description: "Alamofire")
         let client = ApiClient(baseUrl: "https://apibase", apiKey: "", credentials: credentials, persistor: InMemoryPersistor())

--- a/ios/Analytics/Tests/AnalyticsApiTests.swift
+++ b/ios/Analytics/Tests/AnalyticsApiTests.swift
@@ -101,7 +101,7 @@ final class AnalyticsApiTests: XCTestCase {
     func testGetAggregatedDailyStats() {
         let e = expectation(description: "Alamofire")
         let client = ApiClient(baseUrl: "https://apibase", apiKey: "", credentials: credentials, persistor: InMemoryPersistor())
-        client.analytics.dailyStatsAggregate(from: Date.distantPast, to: Date.distantFuture, aggregation: AggregationType.sum) { result in
+        client.analytics.aggregatedDailyStats(from: Date.distantPast, to: Date.distantFuture, aggregation: AggregationType.sum) { result in
             switch result {
             case .success(let stat):
                 XCTAssertEqual(stat.moderate.seconds, 160)

--- a/ios/ExampleApp/ExampleApp.xcodeproj/project.pbxproj
+++ b/ios/ExampleApp/ExampleApp.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		44F8883726C533FE005B0BBD /* AggregatedDailyStatsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44F8883626C533FE005B0BBD /* AggregatedDailyStatsScreen.swift */; };
+		44F8883926C53474005B0BBD /* AggregatedDailyStatsObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44F8883826C53474005B0BBD /* AggregatedDailyStatsObservable.swift */; };
 		4C3D6A8D25BACB0000729276 /* FjuulApiBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C3D6A8C25BACB0000729276 /* FjuulApiBuilder.swift */; };
 		4C4A4DEE25F79C4300A944C2 /* SyncHealthKitActivitySource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C4A4DED25F79C4300A944C2 /* SyncHealthKitActivitySource.swift */; };
 		4C4A4DF225F7BFB400A944C2 /* CheckboxField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C4A4DF125F7BFB400A944C2 /* CheckboxField.swift */; };
@@ -51,6 +53,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		44F8883626C533FE005B0BBD /* AggregatedDailyStatsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AggregatedDailyStatsScreen.swift; sourceTree = "<group>"; };
+		44F8883826C53474005B0BBD /* AggregatedDailyStatsObservable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AggregatedDailyStatsObservable.swift; sourceTree = "<group>"; };
 		4C3D6A8C25BACB0000729276 /* FjuulApiBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FjuulApiBuilder.swift; sourceTree = "<group>"; };
 		4C4A4DED25F79C4300A944C2 /* SyncHealthKitActivitySource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncHealthKitActivitySource.swift; sourceTree = "<group>"; };
 		4C4A4DF125F7BFB400A944C2 /* CheckboxField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckboxField.swift; sourceTree = "<group>"; };
@@ -124,6 +128,7 @@
 			isa = PBXGroup;
 			children = (
 				B348CE8924D85711001DCE14 /* ActivitySourceObservable.swift */,
+				44F8883826C53474005B0BBD /* AggregatedDailyStatsObservable.swift */,
 				B3548D6D24CF1FC4002F26B9 /* DailyStatsObservable.swift */,
 				B3548D6B24CF1E25002F26B9 /* UserProfileObservable.swift */,
 				4C4A4DF525F7C94700A944C2 /* HealthKitSyncObservable.swift */,
@@ -211,6 +216,7 @@
 				B348CE8724D85551001DCE14 /* ActivitySourcesScreen.swift */,
 				B3548D6024CF0F62002F26B9 /* CreateUserScreen.swift */,
 				B3548D6124CF0F62002F26B9 /* DailyStatsScreen.swift */,
+				44F8883626C533FE005B0BBD /* AggregatedDailyStatsScreen.swift */,
 				B3548D6424CF0F7B002F26B9 /* ModuleSelectionScreens.swift */,
 				B3548D6624CF0F91002F26B9 /* OnboardingScreen.swift */,
 				B3548D6824CF0FA8002F26B9 /* UserProfileScreen.swift */,
@@ -347,6 +353,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				44F8883926C53474005B0BBD /* AggregatedDailyStatsObservable.swift in Sources */,
+				44F8883726C533FE005B0BBD /* AggregatedDailyStatsScreen.swift in Sources */,
 				B3548D6924CF0FA8002F26B9 /* UserProfileScreen.swift in Sources */,
 				4C4A4DEE25F79C4300A944C2 /* SyncHealthKitActivitySource.swift in Sources */,
 				B3FBCDBA24B8D5A400184A88 /* LazyView.swift in Sources */,

--- a/ios/ExampleApp/ExampleApp/Models/AggregatedDailyStatsObservable.swift
+++ b/ios/ExampleApp/ExampleApp/Models/AggregatedDailyStatsObservable.swift
@@ -22,7 +22,7 @@ class AggregatedDailyStatsObservable: ObservableObject {
 
     func fetch(_ fromDate: Date, _ toDate: Date, _ aggregation: AggregationType) {
         self.isLoading = true
-        ApiClientHolder.default.apiClient?.analytics.dailyStatsAggregate(from: fromDate, to: toDate, aggregation: aggregation) { result in
+        ApiClientHolder.default.apiClient?.analytics.aggregatedDailyStats(from: fromDate, to: toDate, aggregation: aggregation) { result in
             self.isLoading = false
             switch result {
             case .success(let aggregatedDailyStats): self.value = aggregatedDailyStats

--- a/ios/ExampleApp/ExampleApp/Models/AggregatedDailyStatsObservable.swift
+++ b/ios/ExampleApp/ExampleApp/Models/AggregatedDailyStatsObservable.swift
@@ -10,24 +10,22 @@ class AggregatedDailyStatsObservable: ObservableObject {
     @Published var fromDate: Date = Date()
     @Published var toDate: Date = Date()
     @Published var aggregation: AggregationType = .sum
-    @Published var value: AggregatedDailyStats 
+    @Published var value: AggregatedDailyStats?
 
     private var dateObserver: AnyCancellable?
 
     init() {
-        dateObserver = $fromDate.combineLatest($toDate).sink { (fromDate, toDate) in
-            self.fetch(fromDate, toDate)
+        dateObserver = $fromDate.combineLatest($toDate, $aggregation).sink { (fromDate, toDate, aggregation) in
+            self.fetch(fromDate, toDate, aggregation)
         }
     }
 
-    func fetch(_ fromDate: Date, _ toDate: Date, _ aggregation: aggregation) {
-        self.value = undefined
+    func fetch(_ fromDate: Date, _ toDate: Date, _ aggregation: AggregationType) {
         self.isLoading = true
         ApiClientHolder.default.apiClient?.analytics.dailyStatsAggregate(from: fromDate, to: toDate, aggregation: aggregation) { result in
             self.isLoading = false
             switch result {
-            case .success(let aggregatedDailyStats):
-                self.value = dailyStats.sorted(by: { $0.date.compare($1.date) == .orderedDescending })
+            case .success(let aggregatedDailyStats): self.value = aggregatedDailyStats
             case .failure(let err): self.error = ErrorHolder(error: err)
             }
         }

--- a/ios/ExampleApp/ExampleApp/Models/AggregatedDailyStatsObservable.swift
+++ b/ios/ExampleApp/ExampleApp/Models/AggregatedDailyStatsObservable.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Combine
+import FjuulAnalytics
+
+class AggregatedDailyStatsObservable: ObservableObject {
+
+    @Published var isLoading: Bool = false
+    @Published var error: ErrorHolder?
+
+    @Published var fromDate: Date = Date()
+    @Published var toDate: Date = Date()
+    @Published var aggregation: AggregationType = .sum
+    @Published var value: AggregatedDailyStats 
+
+    private var dateObserver: AnyCancellable?
+
+    init() {
+        dateObserver = $fromDate.combineLatest($toDate).sink { (fromDate, toDate) in
+            self.fetch(fromDate, toDate)
+        }
+    }
+
+    func fetch(_ fromDate: Date, _ toDate: Date, _ aggregation: aggregation) {
+        self.value = undefined
+        self.isLoading = true
+        ApiClientHolder.default.apiClient?.analytics.dailyStatsAggregate(from: fromDate, to: toDate, aggregation: aggregation) { result in
+            self.isLoading = false
+            switch result {
+            case .success(let aggregatedDailyStats):
+                self.value = dailyStats.sorted(by: { $0.date.compare($1.date) == .orderedDescending })
+            case .failure(let err): self.error = ErrorHolder(error: err)
+            }
+        }
+    }
+
+}

--- a/ios/ExampleApp/ExampleApp/Screens/AggregatedDailyStatsScreen.swift
+++ b/ios/ExampleApp/ExampleApp/Screens/AggregatedDailyStatsScreen.swift
@@ -10,7 +10,7 @@ struct AggregatedDailyStatsScreen: View {
         formatter.dateStyle = .long
         return formatter
     }()
-    
+
     var body: some View {
         Form {
             Section {

--- a/ios/ExampleApp/ExampleApp/Screens/AggregatedDailyStatsScreen.swift
+++ b/ios/ExampleApp/ExampleApp/Screens/AggregatedDailyStatsScreen.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import FjuulAnalytics
 
 struct AggregatedDailyStatsScreen: View {
 
@@ -9,13 +10,19 @@ struct AggregatedDailyStatsScreen: View {
         formatter.dateStyle = .long
         return formatter
     }()
-
+    
+    @State var selection: AggregationType = .sum
+    
     var body: some View {
         Form {
             Section {
                 DatePicker(selection: $aggregatedStats.fromDate, displayedComponents: .date, label: { Text("From") })
                 DatePicker(selection: $aggregatedStats.toDate, displayedComponents: .date, label: { Text("To") })
-                
+                Picker("Aggregate", selection: $selection) {
+                    ForEach(AggregationType.allCases, id: \.rawValue) { type in
+                        Text(type.rawValue).tag(type)
+                    }
+                }.pickerStyle(SegmentedPickerStyle())
             }
             Section(header: Text("Results")) {
                 if aggregatedStats.isLoading {

--- a/ios/ExampleApp/ExampleApp/Screens/AggregatedDailyStatsScreen.swift
+++ b/ios/ExampleApp/ExampleApp/Screens/AggregatedDailyStatsScreen.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+
+struct AggregatedDailyStatsScreen: View {
+
+    @ObservedObject var aggregatedStats = AggregatedDailyStatsObservable()
+
+    static let taskDateFormat: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .long
+        return formatter
+    }()
+
+    var body: some View {
+        Form {
+            Section {
+                DatePicker(selection: $aggregatedStats.fromDate, displayedComponents: .date, label: { Text("From") })
+                DatePicker(selection: $aggregatedStats.toDate, displayedComponents: .date, label: { Text("To") })
+                
+            }
+            Section(header: Text("Results")) {
+                if aggregatedStats.isLoading {
+                    Text("Loading")
+                } else {
+                    List(aggregatedStats.value, id: \.date) { each in
+                        VStack(alignment: .leading, spacing: 4) {
+                            HStack {
+                                Image(systemName: "bolt")
+                                    .frame(width: 30, height: 10, alignment: .leading)
+                                Text("low \(each.low.metMinutes, specifier: "%.1f")")
+                                Spacer()
+                                Text("\(self.formatTime(time: each.low.seconds))")
+                            }
+                            HStack {
+                                Image(systemName: "bolt")
+                                    .frame(width: 30, height: 10, alignment: .leading)
+                                Text("mod \(each.moderate.metMinutes, specifier: "%.1f")")
+                                Spacer()
+                                Text("\(self.formatTime(time: each.moderate.seconds))")
+                            }
+                            HStack {
+                                Image(systemName: "bolt")
+                                    .frame(width: 30, height: 10, alignment: .leading)
+                                Text("high \(each.high.metMinutes, specifier: "%.1f")")
+                                Spacer()
+                                Text("\(self.formatTime(time: each.high.seconds))")
+                            }
+                            HStack {
+                                Image(systemName: "flame")
+                                    .frame(width: 30, height: 10, alignment: .leading)
+                                Text("activeKcal \(each.activeKcal, specifier: "%.1f")")
+                            }
+                            HStack {
+                                Image(systemName: "bolt.heart")
+                                    .frame(width: 30, height: 10, alignment: .leading)
+                                Text("bmr \(each.bmr, specifier: "%.1f")")
+                            }
+                        }.padding(.top, 5)
+                    }
+                }
+            }
+        }
+        .alert(item: $aggregatedStats.error) { holder in
+            Alert(title: Text(holder.error.localizedDescription))
+        }
+        .navigationBarTitle("Aggregated Daily Stats")
+    }
+
+    func formatTime(time: TimeInterval, units: NSCalendar.Unit = [.hour, .minute]) -> String {
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = units
+        formatter.unitsStyle = .abbreviated
+        formatter.zeroFormattingBehavior = .pad
+
+        return formatter.string(from: time) ?? ""
+    }
+}
+
+struct AggregatedDailyStatsScreen_Previews: PreviewProvider {
+    static var previews: some View {
+        Group {
+            AggregatedDailyStatsScreen()
+        }
+    }
+}

--- a/ios/ExampleApp/ExampleApp/Screens/AggregatedDailyStatsScreen.swift
+++ b/ios/ExampleApp/ExampleApp/Screens/AggregatedDailyStatsScreen.swift
@@ -11,14 +11,12 @@ struct AggregatedDailyStatsScreen: View {
         return formatter
     }()
     
-    @State var selection: AggregationType = .sum
-    
     var body: some View {
         Form {
             Section {
                 DatePicker(selection: $aggregatedStats.fromDate, displayedComponents: .date, label: { Text("From") })
                 DatePicker(selection: $aggregatedStats.toDate, displayedComponents: .date, label: { Text("To") })
-                Picker("Aggregate", selection: $selection) {
+                Picker("Aggregate", selection: $aggregatedStats.aggregation) {
                     ForEach(AggregationType.allCases, id: \.rawValue) { type in
                         Text(type.rawValue).tag(type)
                     }

--- a/ios/ExampleApp/ExampleApp/Screens/AggregatedDailyStatsScreen.swift
+++ b/ios/ExampleApp/ExampleApp/Screens/AggregatedDailyStatsScreen.swift
@@ -21,41 +21,40 @@ struct AggregatedDailyStatsScreen: View {
                 if aggregatedStats.isLoading {
                     Text("Loading")
                 } else {
-                    List(aggregatedStats.value, id: \.date) { each in
-                        VStack(alignment: .leading, spacing: 4) {
-                            HStack {
-                                Image(systemName: "bolt")
-                                    .frame(width: 30, height: 10, alignment: .leading)
-                                Text("low \(each.low.metMinutes, specifier: "%.1f")")
-                                Spacer()
-                                Text("\(self.formatTime(time: each.low.seconds))")
-                            }
-                            HStack {
-                                Image(systemName: "bolt")
-                                    .frame(width: 30, height: 10, alignment: .leading)
-                                Text("mod \(each.moderate.metMinutes, specifier: "%.1f")")
-                                Spacer()
-                                Text("\(self.formatTime(time: each.moderate.seconds))")
-                            }
-                            HStack {
-                                Image(systemName: "bolt")
-                                    .frame(width: 30, height: 10, alignment: .leading)
-                                Text("high \(each.high.metMinutes, specifier: "%.1f")")
-                                Spacer()
-                                Text("\(self.formatTime(time: each.high.seconds))")
-                            }
-                            HStack {
-                                Image(systemName: "flame")
-                                    .frame(width: 30, height: 10, alignment: .leading)
-                                Text("activeKcal \(each.activeKcal, specifier: "%.1f")")
-                            }
-                            HStack {
-                                Image(systemName: "bolt.heart")
-                                    .frame(width: 30, height: 10, alignment: .leading)
-                                Text("bmr \(each.bmr, specifier: "%.1f")")
-                            }
-                        }.padding(.top, 5)
-                    }
+                    let stats = aggregatedStats.value!
+                    VStack(alignment: .leading, spacing: 4) {
+                        HStack {
+                            Image(systemName: "bolt")
+                                .frame(width: 30, height: 10, alignment: .leading)
+                            Text("low \(stats.low.metMinutes, specifier: "%.1f")")
+                            Spacer()
+                            Text("\(self.formatTime(time: stats.low.seconds))")
+                        }
+                        HStack {
+                            Image(systemName: "bolt")
+                                .frame(width: 30, height: 10, alignment: .leading)
+                            Text("mod \(stats.moderate.metMinutes, specifier: "%.1f")")
+                            Spacer()
+                            Text("\(self.formatTime(time: stats.moderate.seconds))")
+                        }
+                        HStack {
+                            Image(systemName: "bolt")
+                                .frame(width: 30, height: 10, alignment: .leading)
+                            Text("high \(stats.high.metMinutes, specifier: "%.1f")")
+                            Spacer()
+                            Text("\(self.formatTime(time: stats.high.seconds))")
+                        }
+                        HStack {
+                            Image(systemName: "flame")
+                                .frame(width: 30, height: 10, alignment: .leading)
+                            Text("activeKcal \(stats.activeKcal, specifier: "%.1f")")
+                        }
+                        HStack {
+                            Image(systemName: "bolt.heart")
+                                .frame(width: 30, height: 10, alignment: .leading)
+                            Text("bmr \(stats.bmr, specifier: "%.1f")")
+                        }
+                    }.padding(.top, 5)
                 }
             }
         }

--- a/ios/ExampleApp/ExampleApp/Screens/ModuleSelectionScreens.swift
+++ b/ios/ExampleApp/ExampleApp/Screens/ModuleSelectionScreens.swift
@@ -17,6 +17,9 @@ struct ModuleSelectionScreens: View {
                 NavigationLink(destination: LazyView(DailyStatsScreen())) {
                     Text("Daily Statistics")
                 }
+                NavigationLink(destination: LazyView(AggregatedDailyStatsScreen())) {
+                    Text("Aggregated Daily Statistics")
+                }
             }
         }
         .navigationBarTitle("Modules", displayMode: .inline)

--- a/ios/User/Sources/UserApi.swift
+++ b/ios/User/Sources/UserApi.swift
@@ -81,7 +81,7 @@ public class UserApi {
                 .tryMap { data -> UserProfile  in
                     let decoder = UserApi.userProfileJSONDecoder
                     let json = try JSONSerialization.jsonObject(with: data)
-                    decoder.userInfo = [UserProfileCodingOptions.key: UserProfileCodingOptions(json: json as? [String : Any])]
+                    decoder.userInfo = [UserProfileCodingOptions.key: UserProfileCodingOptions(json: json as? [String: Any])]
                     return try decoder.decode(UserProfile.self, from: data)
                 }.mapAPIError { _, jsonError in
                     guard let jsonError = jsonError else { return nil }
@@ -102,7 +102,7 @@ public class UserApi {
                 .tryMap { data -> UserProfile in
                     let decoder = UserApi.userProfileJSONDecoder
                     let json = try JSONSerialization.jsonObject(with: data)
-                    decoder.userInfo = [UserProfileCodingOptions.key: UserProfileCodingOptions(json: json as? [String : Any])]
+                    decoder.userInfo = [UserProfileCodingOptions.key: UserProfileCodingOptions(json: json as? [String: Any])]
                     return try decoder.decode(UserProfile.self, from: data)
                 }
                 .mapError { err -> Error in


### PR DESCRIPTION
Summary:

- add getAggregatedDailyStats method to the SDK (iOS and Android) to query sum or average aggregates for provided date range
- add the abovementioned logic to the example apps: 

iOS:
![Simulator Screen Shot - iPhone 12 mini - 2021-08-17 at 10 41 51](https://user-images.githubusercontent.com/11229226/130213213-ccefca35-67dc-4be0-84a4-43d596fd4d96.png)

Android:
![Screenshot_1629451596](https://user-images.githubusercontent.com/11229226/130213249-28ecd3ba-e503-48a9-a5e1-c96c122cbbb9.png)
