### PR TITLE
fix: change default iOS dataTypesToRead (#78)

### DIFF
--- a/ios/ActivitySources/Sources/Activities/HealthKit/HealthKitActivitySourceConfig.swift
+++ b/ios/ActivitySources/Sources/Activities/HealthKit/HealthKitActivitySourceConfig.swift
@@ -39,7 +39,7 @@ public struct HealthKitActivitySourceConfig {
     ///   - dataTypesToRead: List of data types for read from HealthKit.
     ///   - syncUserEnteredData: Enable/Disable sync from HealthKit user manually entered data (default: true).
     ///   - enableBackgroundDelivery: Enable/Disable backgroundDelivery (default: true).
-    public init(dataTypesToRead: [HealthKitConfigType] = HealthKitConfigType.allCases,
+    public init(dataTypesToRead: [HealthKitConfigType] = [.activeEnergyBurned, .distanceCycling, .distanceWalkingRunning, .height, .weight],
                 syncUserEnteredData: Bool = true,
                 enableBackgroundDelivery: Bool = true) {
 


### PR DESCRIPTION
to minimum required for met-minute logic (instead of all types)