### PR TITLE
chore: declare retroactive `Optional` conformance

### DIFF
--- a/ios/Core/Sources/Entities/SigningKey.swift
+++ b/ios/Core/Sources/Entities/SigningKey.swift
@@ -19,7 +19,7 @@ extension SigningKey: AuthenticationCredential {
 
 }
 
-extension Optional: AuthenticationCredential where Wrapped == SigningKey {
+extension Optional: @retroactive AuthenticationCredential where Wrapped == SigningKey {
 
     public var requiresRefresh: Bool {
         guard let value = self else {


### PR DESCRIPTION
of `AuthenticationCredential`. This is needed in order for `HmacAuthenticator` to conform to the `Authenticator` protocol.