### PR TITLE
refactor: harmonize permission utility naming

### DIFF
--- a/android/ExampleApp/app/src/main/java/com/fjuul/sdk/android/exampleapp/ui/activity_sources/ActivitySourcesFragment.kt
+++ b/android/ExampleApp/app/src/main/java/com/fjuul/sdk/android/exampleapp/ui/activity_sources/ActivitySourcesFragment.kt
@@ -184,7 +184,7 @@ class ActivitySourcesFragment : Fragment() {
                     .setTitle("Health Connect")
                     .setItems(menus) { _, which ->
                         if (which == 0) {
-                            hcPermsLauncher.launch(activitySource.getPermissionManager().requiredAllPermissions())
+                            hcPermsLauncher.launch(activitySource.getPermissionManager().allRequiredPermissions())
                         } else {
                             model.disconnect(activitySource)
                         }
@@ -205,7 +205,7 @@ class ActivitySourcesFragment : Fragment() {
             activitySource.getPermissionManager().requestPermissionsContract()
         ) { grantedPermissions ->
             // Compute which permissions were denied
-            val required = activitySource.getPermissionManager().requiredAllPermissions()
+            val required = activitySource.getPermissionManager().allRequiredPermissions()
             val denied = required - grantedPermissions
 
             if (denied.isEmpty()) {

--- a/android/activitysources/src/main/java/com/fjuul/sdk/activitysources/entities/HealthConnectActivitySource.kt
+++ b/android/activitysources/src/main/java/com/fjuul/sdk/activitysources/entities/HealthConnectActivitySource.kt
@@ -70,7 +70,7 @@ class HealthConnectActivitySource private constructor(
     fun syncIntraday(options: HealthConnectSyncOptions, callback: Callback<Unit>) =
         executeSynchronized({
             permissionManager.ensureSdkAvailable()
-            permissionManager.ensureHealthPermissionGranted(options.metrics)
+            permissionManager.ensureMetricPermissionsGranted(options.metrics)
             lowerDateBoundary?.let { dataManager.syncIntraday(options, it) }
         }, callback)
 
@@ -83,7 +83,7 @@ class HealthConnectActivitySource private constructor(
     fun syncDaily(options: HealthConnectSyncOptions, callback: Callback<Unit>) =
         executeSynchronized({
             permissionManager.ensureSdkAvailable()
-            permissionManager.ensureHealthPermissionGranted(options.metrics)
+            permissionManager.ensureMetricPermissionsGranted(options.metrics)
             lowerDateBoundary?.let { dataManager.syncDaily(options, it) }
         }, callback)
 
@@ -96,7 +96,7 @@ class HealthConnectActivitySource private constructor(
     fun syncProfile(options: HealthConnectSyncOptions, callback: Callback<Unit>) =
         executeSynchronized({
             permissionManager.ensureSdkAvailable()
-            permissionManager.ensureHealthPermissionGranted(options.metrics)
+            permissionManager.ensureMetricPermissionsGranted(options.metrics)
             lowerDateBoundary?.let { dataManager.syncProfile(options, it) }
         }, callback)
 

--- a/android/activitysources/src/main/java/com/fjuul/sdk/activitysources/workers/HCDailySyncWorker.kt
+++ b/android/activitysources/src/main/java/com/fjuul/sdk/activitysources/workers/HCDailySyncWorker.kt
@@ -20,7 +20,7 @@ class HCDailySyncWorker(context: Context, workerParams: WorkerParameters) :
         val hcSource = (hcConnection.activitySource as HealthConnectActivitySource)
         val permissionManager = hcSource.getPermissionManager()
 
-        if (permissionManager.checkBackgroundPermission()) {
+        if (permissionManager.isBackgroundPermissionGranted()) {
             val taskCompletionSource = TaskCompletionSource<Void?>()
             val syncOptions = buildDailySyncOptions()
 

--- a/android/activitysources/src/main/java/com/fjuul/sdk/activitysources/workers/HCIntradaySyncWorker.kt
+++ b/android/activitysources/src/main/java/com/fjuul/sdk/activitysources/workers/HCIntradaySyncWorker.kt
@@ -20,7 +20,7 @@ class HCIntradaySyncWorker(context: Context, workerParams: WorkerParameters) :
         val hcSource = (hcConnection.activitySource as HealthConnectActivitySource)
         val permissionManager = hcSource.getPermissionManager()
 
-        if (permissionManager.checkBackgroundPermission()) {
+        if (permissionManager.isBackgroundPermissionGranted()) {
             val taskCompletionSource = TaskCompletionSource<Void?>()
             val syncOptions = buildIntradaySyncOptions()
             hcSource.syncIntraday(syncOptions) { result ->

--- a/android/activitysources/src/main/java/com/fjuul/sdk/activitysources/workers/HCProfileSyncWorker.kt
+++ b/android/activitysources/src/main/java/com/fjuul/sdk/activitysources/workers/HCProfileSyncWorker.kt
@@ -20,7 +20,7 @@ class HCProfileSyncWorker(context: Context, workerParams: WorkerParameters) :
         val hcSource = (hcConnection.activitySource as HealthConnectActivitySource)
         val permissionManager = hcSource.getPermissionManager()
 
-        if (permissionManager.checkBackgroundPermission()) {
+        if (permissionManager.isBackgroundPermissionGranted()) {
             val taskCompletionSource = TaskCompletionSource<Void>()
             val syncOptions = buildProfileSyncOptions()
             hcSource.syncProfile(syncOptions) { result ->


### PR DESCRIPTION
* the checkXYZ utils were renamed to is…Granted to clarify the boolean return type
* the ensureXYZ utils consistently throw Exceptions
* the is…Granted utils consistently do not throw Exceptions